### PR TITLE
Change order of config setting in factory

### DIFF
--- a/rabbitmq/src/test/java/io/karatelabs/examples/rabbitMQ/KarateRMQConsumer.java
+++ b/rabbitmq/src/test/java/io/karatelabs/examples/rabbitMQ/KarateRMQConsumer.java
@@ -17,8 +17,8 @@ public class KarateRmqConsumer {
     static final Logger logger = LoggerFactory.getLogger(KarateRmqConsumer.class);
     
     private final ConnectionFactory factory = new ConnectionFactory();
-    private final Connection connection = factory.newConnection();
-    private final Channel channel = connection.createChannel();
+    private final Connection connection;
+    private final Channel channel;
     public static List<String> messages = new ArrayList<>();
     
     private final String queueName;
@@ -26,6 +26,8 @@ public class KarateRmqConsumer {
     public KarateRmqConsumer(String queueName) throws IOException, TimeoutException {
         this.queueName = queueName;
         factory.setHost("localhost");
+        connection = factory.newConnection();
+        channel = connection.createChannel();
         channel.queueDeclare(queueName, false, false, false, null);
         logger.debug("init consumer, waiting for messages ...");
         listen();

--- a/rabbitmq/src/test/java/io/karatelabs/examples/rabbitMQ/KarateRMQProducer.java
+++ b/rabbitmq/src/test/java/io/karatelabs/examples/rabbitMQ/KarateRMQProducer.java
@@ -20,12 +20,11 @@ public class KarateRmqProducer {
         this.queueName = queueName;
         try {
             ConnectionFactory factory = new ConnectionFactory();
-            Connection connection;
-            connection = factory.newConnection();
             factory.setUsername("guest");
             factory.setPassword("guest");
             factory.setHost("localhost");
             factory.setPort(5672);
+            Connection connection = factory.newConnection();
             channel = connection.createChannel();
             channel.queueDeclare(queueName, false, false, false, null);
             logger.debug("init producer");


### PR DESCRIPTION
As described in RabbitMQ Guide(https://www.rabbitmq.com/docs/api-guide), configuration(such as host, port, etc) should be set in `ConnectionFactory` instance before creating a new connection with `newConnection()` method.

Otherwise, we will get `Connection Refused` errors which I've gotten upon using this RabbitMQxKarate Demo..